### PR TITLE
fix for IRDIS pixel scale, option for top colourbar, self.velocity no longer needed

### DIFF
--- a/casa_cube/cube.py
+++ b/casa_cube/cube.py
@@ -397,8 +397,8 @@ class Cube:
 
             # Averaging multiple channels
             v_offset = 0.0
-            dv = np.diff(self.velocity)[0]
             if width is not None:
+                dv = np.diff(self.velocity)[0]
                 n_channels = np.maximum(int(np.round(width/dv)),1)
 
                 if n_channels%2: # odd number of channels, same central channel

--- a/casa_cube/cube.py
+++ b/casa_cube/cube.py
@@ -1,14 +1,15 @@
 import os
-import numpy as np
-from astropy.io import fits
-import scipy.constants as sc
-import matplotlib.pyplot as plt
-import matplotlib.colors as mcolors
-from matplotlib.patches import Ellipse
-from astropy.convolution import Gaussian2DKernel, convolve_fft
-from scipy import ndimage
-import cmasher as cmr
+from copy import deepcopy
 
+import cmasher as cmr
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.constants as sc
+from astropy.convolution import Gaussian2DKernel, convolve_fft
+from astropy.io import fits
+from matplotlib.patches import Ellipse
+from scipy import ndimage
 
 FWHM_to_sigma = 1.0 / (2.0 * np.sqrt(2.0 * np.log(2)))
 arcsec = np.pi / 648000
@@ -201,13 +202,9 @@ class Cube:
             print('cannot open', self.filename)
             return ValueError
 
-
     def cutout(self, filename, FOV=None, ix_min=None, ix_max=None, iv_min=None, iv_max=None, vmin=None, vmax=None, no_pola=False, pmin=None, pmax=None, channels=None, **kwargs):
-
-        import copy
-
-        image = copy.deepcopy(self.image)
-        header = copy.deepcopy(self.header)
+        image = deepcopy(self.image)
+        header = deepcopy(self.header)
 
         ndim = image.ndim
 

--- a/casa_cube/cube.py
+++ b/casa_cube/cube.py
@@ -325,7 +325,7 @@ class Cube:
         M0_threshold=None,
         M8_threshold=None,
         threshold = None,
-        threshold_value = np.NaN,
+        threshold_value=np.nan,
         vlabel_position="bottom",
         vlabel_color="white",
         vlabel_size=8,
@@ -574,7 +574,7 @@ class Cube:
             #divider = make_axes_locatable(ax)
             #cax = divider.append_axes("right", size="5%", pad=0.05)
             #cb = plt.colorbar(image, cax=cax, extend=colorbar_extend)
-            cb = add_colorbar(image)
+            cb = add_colorbar(image, shift=0.01)
 
             # cax,kw = mpl.colorbar.make_axes(ax)
             # cb = plt.colorbar(image,cax=cax, **kw)

--- a/casa_cube/cube.py
+++ b/casa_cube/cube.py
@@ -81,9 +81,9 @@ class Cube:
                     pixelscale = 12.255e-3
                 elif instrument == "IRDIS_H3":
                     pixelscale = 12.250e-3
-                elif instrument == "IRDIS_K2":
+                elif instrument == "IRDIS_K1":
                     pixelscale = 12.267e-3
-                elif instrument == "IRDIS_K3":
+                elif instrument == "IRDIS_K2":
                     pixelscale = 12.263e-3
                 elif instrument == "IRDIS_BB_J":
                     pixelscale = 12.263e-3
@@ -322,6 +322,7 @@ class Cube:
         bpa=None,
         taper=None,
         colorbar_label=True,
+        colorbar_side="right",
         M0_threshold=None,
         M8_threshold=None,
         threshold = None,
@@ -574,7 +575,10 @@ class Cube:
             #divider = make_axes_locatable(ax)
             #cax = divider.append_axes("right", size="5%", pad=0.05)
             #cb = plt.colorbar(image, cax=cax, extend=colorbar_extend)
-            cb = add_colorbar(image)
+            cb = add_colorbar(image, side=colorbar_side)
+            if colorbar_side == "top":
+                cb.ax.xaxis.set_ticks_position('top')
+                cb.ax.xaxis.set_label_position('top')
 
             # cax,kw = mpl.colorbar.make_axes(ax)
             # cb = plt.colorbar(image,cax=cax, **kw)
@@ -869,13 +873,13 @@ def add_colorbar(mappable, shift=None, width=0.05, ax=None, trim_left=0, trim_ri
 
     if side=="top":
         if shift is None:
-            shift = 0.2
+            shift = 0.02
         cax = fig.add_axes([xmin + trim_left, ymax + shift * dy, dx - trim_left - trim_right, width * dy])
         cax.xaxis.set_ticks_position('top')
         return fig.colorbar(mappable, cax=cax, orientation="horizontal",**kwargs)
     elif side=="right":
         if shift is None:
-            shift = 0.05
+            shift = 0.02
         cax = fig.add_axes([xmax + shift*dx, ymin, width * dx, dy])
         cax.xaxis.set_ticks_position('top')
         return fig.colorbar(mappable, cax=cax, orientation="vertical",**kwargs)

--- a/casa_cube/cube.py
+++ b/casa_cube/cube.py
@@ -574,7 +574,7 @@ class Cube:
             #divider = make_axes_locatable(ax)
             #cax = divider.append_axes("right", size="5%", pad=0.05)
             #cb = plt.colorbar(image, cax=cax, extend=colorbar_extend)
-            cb = add_colorbar(image, shift=0.01)
+            cb = add_colorbar(image)
 
             # cax,kw = mpl.colorbar.make_axes(ax)
             # cb = plt.colorbar(image,cax=cax, **kw)

--- a/casa_cube/cube.py
+++ b/casa_cube/cube.py
@@ -68,7 +68,7 @@ class Cube:
 
                 # SPHERE pixelscales (Maire et al 2016)
                 if instrument == "IFS":
-                    pixelscale = 7.36e-3
+                    pixelscale = 7.46e-3
                 elif instrument == "IRDIS_Y2":
                     pixelscale = 12.283e-3
                 elif instrument == "IRDIS_Y3":

--- a/casa_cube/cube.py
+++ b/casa_cube/cube.py
@@ -35,7 +35,7 @@ class Cube:
             try:
                 self.unit = hdu[0].header['BUNIT']
             except:
-                print("Warning: could not find unit")
+                print("Warning: could not find header keyword BUNIT")
                 self.unit = ""
 
             if unit is not None:
@@ -279,9 +279,9 @@ class Cube:
                 header['NAXIS4'] = 1
 
         # trimming cube
-        if (image.ndim == 4):
-            image = image[p_min:p_max,iv_min:iv_max,iy_min:iy_max,ix_min:ix_max]
-        elif (image.ndim == 3):
+        if image.ndim == 4:
+            image = image[pmin:pmax,iv_min:iv_max,iy_min:iy_max,ix_min:ix_max]
+        elif image.ndim == 3:
             image = image[iv_min:iv_max,iy_min:iy_max,ix_min:ix_max]
         else:
             raise ValueError("incorrect dimension in fits file")


### PR DESCRIPTION
Pretty much does what it says. There's a new argument `colorbar_side` to allow placement of the colour bar on the right (default) or top of the figure. This already existed in the code and just wasn't an argument to `plot`. The large gap between the figure and the colour bar has been reduced in both cases. Finally `self.velocity` doesn't need to be defined if `width` is None