### PR TITLE
(plot) added option use_wcs to plot in wcs coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ import casa_cube as casa
 obs = casa.Cube('HD169142_2015-05-03_Q_phi.fits',pixelscale=0.01225)
 obs.plot()
 ```
+
+## How to plot with RA and Dec on axes instead of relative offsets from image centre
+```
+import casa_cube as casa
+
+obs = casa.Cube('IMLup_continuum.fits')
+ax = plt.subplot(1,1,1,projection=obs.wcs)
+obs.plot(ax)
+```


### PR DESCRIPTION
added option use_wcs to the plot method, so as to be able to plot images in world coordinates (RA, Dec). This is mainly useful for aligning/centering images of the same patch of sky e.g. at different wavelengths or taken with different telescopes.

Example plot:
![orion-askap-3band](https://github.com/user-attachments/assets/ae344e91-915e-4566-a591-00b35cb53212)

Example usage:

```
obs = casa.Cube('image.fits')

delta = 10/60  # 10 arcmin in degrees
ra_center = 83.84  # RA of M42 in degrees
dec_center = -5.38  # Dec of M42 in degrees

limits = [ra_center + delta/np.cos(dec_center*np.pi/180), 
         ra_center - delta/np.cos(dec_center*np.pi/180), 
         dec_center - delta, 
         dec_center + delta]

obs.plot(ax=ax, color_scale='lin', cmap='inferno', Tb=True,use_wcs=True,limits=limits)
plt.show()
```